### PR TITLE
[FEAT] add auto configuration and activation options for lifecycle nodes in launch files

### DIFF
--- a/launch/bbox_to_3d.launch.py
+++ b/launch/bbox_to_3d.launch.py
@@ -13,20 +13,20 @@ def generate_launch_description():
     default_params_file = os.path.join(pkg_dir, 'config', 'bbox_to_3d.yaml')
     
     params_file = LaunchConfiguration('params_file')
-    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
-    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
+    auto_configure = LaunchConfiguration('auto_configure')
+    auto_activate = LaunchConfiguration('auto_activate')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
         description='Full path to the ROS2 parameters file to use'
     )
-    auto_configure_3d_arg = DeclareLaunchArgument(
-        'auto_configure_3d',
+    auto_configure_arg = DeclareLaunchArgument(
+        'auto_configure',
         default_value='False',
         description='Whether to configure the lifecycle node on startup'
     )
-    auto_activate_3d_arg = DeclareLaunchArgument(
-        'auto_activate_3d',
+    auto_activate_arg = DeclareLaunchArgument(
+        'auto_activate',
         default_value='False',
         description='Whether to activate the lifecycle node on startup'
     )
@@ -83,18 +83,18 @@ def generate_launch_description():
 
     return LaunchDescription([
         params_file_arg,
-        auto_configure_3d_arg,
-        auto_activate_3d_arg,
+        auto_configure_arg,
+        auto_activate_arg,
         namespace_cmd,
         container,
         TimerAction(
             period=0.1,
             actions=[configure_node],
-            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+            condition=IfCondition(OrSubstitution(auto_configure, auto_activate)),
         ),
         TimerAction(
             period=0.2,
             actions=[activate_node],
-            condition=IfCondition(auto_activate_3d),
+            condition=IfCondition(auto_activate),
         ),
     ])

--- a/launch/bbox_to_3d.launch.py
+++ b/launch/bbox_to_3d.launch.py
@@ -4,7 +4,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.substitutions import LaunchConfiguration, OrSubstitution, PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
@@ -13,16 +13,22 @@ def generate_launch_description():
     default_params_file = os.path.join(pkg_dir, 'config', 'bbox_to_3d.yaml')
     
     params_file = LaunchConfiguration('params_file')
-    execute_default = LaunchConfiguration('execute_default')
+    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
+    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
         description='Full path to the ROS2 parameters file to use'
     )
-    execute_default_arg = DeclareLaunchArgument(
-        'execute_default',
+    auto_configure_3d_arg = DeclareLaunchArgument(
+        'auto_configure_3d',
         default_value='False',
-        description='Whether to start the node in the active state or not'
+        description='Whether to configure the lifecycle node on startup'
+    )
+    auto_activate_3d_arg = DeclareLaunchArgument(
+        'auto_activate_3d',
+        default_value='False',
+        description='Whether to activate the lifecycle node on startup'
     )
 
     namespace = LaunchConfiguration("namespace")
@@ -77,13 +83,18 @@ def generate_launch_description():
 
     return LaunchDescription([
         params_file_arg,
-        execute_default_arg,
+        auto_configure_3d_arg,
+        auto_activate_3d_arg,
         namespace_cmd,
         container,
-        TimerAction(period=0.1, actions=[configure_node]),
+        TimerAction(
+            period=0.1,
+            actions=[configure_node],
+            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+        ),
         TimerAction(
             period=0.2,
             actions=[activate_node],
-            condition=IfCondition(execute_default),
+            condition=IfCondition(auto_activate_3d),
         ),
     ])

--- a/launch/image_to_3d.launch.py
+++ b/launch/image_to_3d.launch.py
@@ -4,7 +4,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.substitutions import LaunchConfiguration, OrSubstitution, PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
@@ -17,12 +17,18 @@ def generate_launch_description():
     mask_params_file = LaunchConfiguration('mask_params_file')
     bbox_params_file = LaunchConfiguration('bbox_params_file')
     keypoint_params_file = LaunchConfiguration('keypoint_params_file')
-    execute_default = LaunchConfiguration('execute_default')
+    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
+    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
 
-    execute_default_arg = DeclareLaunchArgument(
-        "execute_default",
+    auto_configure_3d_arg = DeclareLaunchArgument(
+        "auto_configure_3d",
         default_value="False",
-        description="Whether to start the nodes in the default state (configured and active) or not (unconfigured)",
+        description="Whether to configure lifecycle nodes on startup",
+    )
+    auto_activate_3d_arg = DeclareLaunchArgument(
+        "auto_activate_3d",
+        default_value="False",
+        description="Whether to activate lifecycle nodes on startup",
     )
 
     mask_params_arg = DeclareLaunchArgument(
@@ -157,28 +163,41 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
-        execute_default_arg,
+        auto_configure_3d_arg,
+        auto_activate_3d_arg,
         mask_params_arg,
         bbox_params_arg,
         keypoint_params_arg,
         namespace_cmd,
         container,
-        TimerAction(period=0.1, actions=[bbox_configure_node]),
-        TimerAction(period=0.1, actions=[mask_configure_node]),
-        TimerAction(period=0.1, actions=[keypoint_configure_node]),
+        TimerAction(
+            period=0.1,
+            actions=[bbox_configure_node],
+            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+        ),
+        TimerAction(
+            period=0.1,
+            actions=[mask_configure_node],
+            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+        ),
+        TimerAction(
+            period=0.1,
+            actions=[keypoint_configure_node],
+            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+        ),
         TimerAction(
             period=0.2,
             actions=[bbox_activate_node],
-            condition=IfCondition(execute_default),
+            condition=IfCondition(auto_activate_3d),
         ),
         TimerAction(
             period=0.2,
             actions=[mask_activate_node],
-            condition=IfCondition(execute_default),
+            condition=IfCondition(auto_activate_3d),
         ),
         TimerAction(
             period=0.2,
             actions=[keypoint_activate_node],
-            condition=IfCondition(execute_default),
+            condition=IfCondition(auto_activate_3d),
         ),
     ])

--- a/launch/image_to_3d.launch.py
+++ b/launch/image_to_3d.launch.py
@@ -17,16 +17,16 @@ def generate_launch_description():
     mask_params_file = LaunchConfiguration('mask_params_file')
     bbox_params_file = LaunchConfiguration('bbox_params_file')
     keypoint_params_file = LaunchConfiguration('keypoint_params_file')
-    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
-    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
+    auto_configure = LaunchConfiguration('auto_configure')
+    auto_activate = LaunchConfiguration('auto_activate')
 
-    auto_configure_3d_arg = DeclareLaunchArgument(
-        "auto_configure_3d",
+    auto_configure_arg = DeclareLaunchArgument(
+        "auto_configure",
         default_value="False",
         description="Whether to configure lifecycle nodes on startup",
     )
-    auto_activate_3d_arg = DeclareLaunchArgument(
-        "auto_activate_3d",
+    auto_activate_arg = DeclareLaunchArgument(
+        "auto_activate",
         default_value="False",
         description="Whether to activate lifecycle nodes on startup",
     )
@@ -163,8 +163,8 @@ def generate_launch_description():
     )
 
     return LaunchDescription([
-        auto_configure_3d_arg,
-        auto_activate_3d_arg,
+        auto_configure_arg,
+        auto_activate_arg,
         mask_params_arg,
         bbox_params_arg,
         keypoint_params_arg,
@@ -173,31 +173,31 @@ def generate_launch_description():
         TimerAction(
             period=0.1,
             actions=[bbox_configure_node],
-            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+            condition=IfCondition(OrSubstitution(auto_configure, auto_activate)),
         ),
         TimerAction(
             period=0.1,
             actions=[mask_configure_node],
-            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+            condition=IfCondition(OrSubstitution(auto_configure, auto_activate)),
         ),
         TimerAction(
             period=0.1,
             actions=[keypoint_configure_node],
-            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+            condition=IfCondition(OrSubstitution(auto_configure, auto_activate)),
         ),
         TimerAction(
             period=0.2,
             actions=[bbox_activate_node],
-            condition=IfCondition(auto_activate_3d),
+            condition=IfCondition(auto_activate),
         ),
         TimerAction(
             period=0.2,
             actions=[mask_activate_node],
-            condition=IfCondition(auto_activate_3d),
+            condition=IfCondition(auto_activate),
         ),
         TimerAction(
             period=0.2,
             actions=[keypoint_activate_node],
-            condition=IfCondition(auto_activate_3d),
+            condition=IfCondition(auto_activate),
         ),
     ])

--- a/launch/keypoint_to_3d.launch.py
+++ b/launch/keypoint_to_3d.launch.py
@@ -13,20 +13,20 @@ def generate_launch_description():
     default_params_file = os.path.join(pkg_dir, 'config', 'keypoint_to_3d.yaml')
     
     params_file = LaunchConfiguration('params_file')
-    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
-    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
+    auto_configure = LaunchConfiguration('auto_configure')
+    auto_activate = LaunchConfiguration('auto_activate')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
         description='Full path to the ROS2 parameters file to use'
     )
-    auto_configure_3d_arg = DeclareLaunchArgument(
-        'auto_configure_3d',
+    auto_configure_arg = DeclareLaunchArgument(
+        'auto_configure',
         default_value='False',
         description='Whether to configure the lifecycle node on startup'
     )
-    auto_activate_3d_arg = DeclareLaunchArgument(
-        'auto_activate_3d',
+    auto_activate_arg = DeclareLaunchArgument(
+        'auto_activate',
         default_value='False',
         description='Whether to activate the lifecycle node on startup'
     )
@@ -83,18 +83,18 @@ def generate_launch_description():
 
     return LaunchDescription([
         params_file_arg,
-        auto_configure_3d_arg,
-        auto_activate_3d_arg,
+        auto_configure_arg,
+        auto_activate_arg,
         namespace_cmd,
         container,
         TimerAction(
             period=0.1,
             actions=[configure_node],
-            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+            condition=IfCondition(OrSubstitution(auto_configure, auto_activate)),
         ),
         TimerAction(
             period=0.2,
             actions=[activate_node],
-            condition=IfCondition(auto_activate_3d),
+            condition=IfCondition(auto_activate),
         ),
     ])

--- a/launch/keypoint_to_3d.launch.py
+++ b/launch/keypoint_to_3d.launch.py
@@ -4,7 +4,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.substitutions import LaunchConfiguration, OrSubstitution, PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
@@ -13,16 +13,22 @@ def generate_launch_description():
     default_params_file = os.path.join(pkg_dir, 'config', 'keypoint_to_3d.yaml')
     
     params_file = LaunchConfiguration('params_file')
-    execute_default = LaunchConfiguration('execute_default')
+    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
+    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
         description='Full path to the ROS2 parameters file to use'
     )
-    execute_default_arg = DeclareLaunchArgument(
-        'execute_default',
+    auto_configure_3d_arg = DeclareLaunchArgument(
+        'auto_configure_3d',
         default_value='False',
-        description='Whether to start the node in the active state or not'
+        description='Whether to configure the lifecycle node on startup'
+    )
+    auto_activate_3d_arg = DeclareLaunchArgument(
+        'auto_activate_3d',
+        default_value='False',
+        description='Whether to activate the lifecycle node on startup'
     )
 
     namespace = LaunchConfiguration("namespace")
@@ -77,13 +83,18 @@ def generate_launch_description():
 
     return LaunchDescription([
         params_file_arg,
-        execute_default_arg,
+        auto_configure_3d_arg,
+        auto_activate_3d_arg,
         namespace_cmd,
         container,
-        TimerAction(period=0.1, actions=[configure_node]),
+        TimerAction(
+            period=0.1,
+            actions=[configure_node],
+            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+        ),
         TimerAction(
             period=0.2,
             actions=[activate_node],
-            condition=IfCondition(execute_default),
+            condition=IfCondition(auto_activate_3d),
         ),
     ])

--- a/launch/mask_to_3d.launch.py
+++ b/launch/mask_to_3d.launch.py
@@ -4,7 +4,7 @@ from ament_index_python.packages import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument, ExecuteProcess, TimerAction
 from launch.conditions import IfCondition
-from launch.substitutions import LaunchConfiguration, PythonExpression
+from launch.substitutions import LaunchConfiguration, OrSubstitution, PythonExpression
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.descriptions import ComposableNode
 
@@ -13,16 +13,22 @@ def generate_launch_description():
     default_params_file = os.path.join(pkg_dir, 'config', 'mask_to_3d.yaml')
     
     params_file = LaunchConfiguration('params_file')
-    execute_default = LaunchConfiguration('execute_default')
+    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
+    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
         description='Full path to the ROS2 parameters file to use'
     )
-    execute_default_arg = DeclareLaunchArgument(
-        'execute_default',
+    auto_configure_3d_arg = DeclareLaunchArgument(
+        'auto_configure_3d',
         default_value='False',
-        description='Whether to start the node in the active state or not'
+        description='Whether to configure the lifecycle node on startup'
+    )
+    auto_activate_3d_arg = DeclareLaunchArgument(
+        'auto_activate_3d',
+        default_value='False',
+        description='Whether to activate the lifecycle node on startup'
     )
 
     namespace = LaunchConfiguration("namespace")
@@ -78,13 +84,18 @@ def generate_launch_description():
 
     return LaunchDescription([
         params_file_arg,
-        execute_default_arg,
+        auto_configure_3d_arg,
+        auto_activate_3d_arg,
         namespace_cmd,
         container,
-        TimerAction(period=0.1, actions=[configure_node]),
+        TimerAction(
+            period=0.1,
+            actions=[configure_node],
+            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+        ),
         TimerAction(
             period=0.2,
             actions=[activate_node],
-            condition=IfCondition(execute_default),
+            condition=IfCondition(auto_activate_3d),
         ),
     ])

--- a/launch/mask_to_3d.launch.py
+++ b/launch/mask_to_3d.launch.py
@@ -13,20 +13,20 @@ def generate_launch_description():
     default_params_file = os.path.join(pkg_dir, 'config', 'mask_to_3d.yaml')
     
     params_file = LaunchConfiguration('params_file')
-    auto_configure_3d = LaunchConfiguration('auto_configure_3d')
-    auto_activate_3d = LaunchConfiguration('auto_activate_3d')
+    auto_configure = LaunchConfiguration('auto_configure')
+    auto_activate = LaunchConfiguration('auto_activate')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
         description='Full path to the ROS2 parameters file to use'
     )
-    auto_configure_3d_arg = DeclareLaunchArgument(
-        'auto_configure_3d',
+    auto_configure_arg = DeclareLaunchArgument(
+        'auto_configure',
         default_value='False',
         description='Whether to configure the lifecycle node on startup'
     )
-    auto_activate_3d_arg = DeclareLaunchArgument(
-        'auto_activate_3d',
+    auto_activate_arg = DeclareLaunchArgument(
+        'auto_activate',
         default_value='False',
         description='Whether to activate the lifecycle node on startup'
     )
@@ -84,18 +84,18 @@ def generate_launch_description():
 
     return LaunchDescription([
         params_file_arg,
-        auto_configure_3d_arg,
-        auto_activate_3d_arg,
+        auto_configure_arg,
+        auto_activate_arg,
         namespace_cmd,
         container,
         TimerAction(
             period=0.1,
             actions=[configure_node],
-            condition=IfCondition(OrSubstitution(auto_configure_3d, auto_activate_3d)),
+            condition=IfCondition(OrSubstitution(auto_configure, auto_activate)),
         ),
         TimerAction(
             period=0.2,
             actions=[activate_node],
-            condition=IfCondition(auto_activate_3d),
+            condition=IfCondition(auto_activate),
         ),
     ])


### PR DESCRIPTION
## Summary

This PR separates lifecycle startup control in `image_to_position` launch files into explicit configure and activate arguments.

Previously, `execute_default` controlled whether lifecycle nodes were brought to the active state after launch. This change replaces that behavior with:
- `auto_configure_3d`
- `auto_activate_3d`

## Changes

- Replaced `execute_default` with `auto_configure_3d` and `auto_activate_3d` in:
  - `launch/bbox_to_3d.launch.py`
  - `launch/keypoint_to_3d.launch.py`
  - `launch/mask_to_3d.launch.py`
  - `launch/image_to_3d.launch.py`
- Updated lifecycle transition timing so:
  - configure is triggered only when either `auto_configure_3d:=True` or `auto_activate_3d:=True`
  - activate is triggered only when `auto_activate_3d:=True`
- Added `OrSubstitution` conditions so activation still implies configuration first

## Why

This makes lifecycle startup behavior more explicit and easier to control.

It allows users to:
- configure lifecycle nodes without immediately activating them
- control startup transitions more precisely
- avoid the ambiguity of a single `execute_default` flag

## Example

```bash
ros2 launch image_to_position bbox_to_3d.launch.py \
  auto_configure_3d:=True \
  auto_activate_3d:=False
  ```
  
##  Behavior
After this change:

- auto_configure_3d:=False, auto_activate_3d:=False
  - node stays unconfigured
- auto_configure_3d:=True, auto_activate_3d:=False
  - node moves to inactive
- auto_activate_3d:=True
  - node is configured first, then activated

## Testing

- Verified all four launch files use the new lifecycle startup arguments consistently
- Confirmed configure actions now depend on auto_configure_3d or auto_activate_3d
- Confirmed activate actions depend only on auto_activate_3d