### PR TITLE
[ADD] sim time param for launchers

### DIFF
--- a/launch/bbox_to_3d.launch.py
+++ b/launch/bbox_to_3d.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
     
     params_file = LaunchConfiguration('params_file')
     execute_default = LaunchConfiguration('execute_default')
+    use_sim_time = LaunchConfiguration('use_sim_time')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
@@ -23,6 +24,11 @@ def generate_launch_description():
         'execute_default',
         default_value='False',
         description='Whether to start the node in the active state or not'
+    )
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='True',
+        description='Use simulation clock.',
     )
 
     namespace = LaunchConfiguration("namespace")
@@ -43,7 +49,7 @@ def generate_launch_description():
                 plugin='image_to_position::BboxTo3D',
                 name='bbox_to_3d',
                 namespace=namespace,
-                parameters=[params_file],
+                parameters=[params_file, {'use_sim_time': use_sim_time}],
                 extra_arguments=[{'use_intra_process_comms': True}]
             ),
         ],
@@ -78,6 +84,7 @@ def generate_launch_description():
     return LaunchDescription([
         params_file_arg,
         execute_default_arg,
+        use_sim_time_arg,
         namespace_cmd,
         container,
         TimerAction(period=0.1, actions=[configure_node]),

--- a/launch/image_to_3d.launch.py
+++ b/launch/image_to_3d.launch.py
@@ -18,6 +18,13 @@ def generate_launch_description():
     bbox_params_file = LaunchConfiguration('bbox_params_file')
     keypoint_params_file = LaunchConfiguration('keypoint_params_file')
     execute_default = LaunchConfiguration('execute_default')
+    use_sim_time = LaunchConfiguration('use_sim_time')
+
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='True',
+        description='Use simulation clock.',
+    )
 
     execute_default_arg = DeclareLaunchArgument(
         "execute_default",
@@ -61,7 +68,7 @@ def generate_launch_description():
                 plugin='image_to_position::BboxTo3D',
                 name='bbox_to_3d',
                 namespace=namespace,
-                parameters=[bbox_params_file],
+                parameters=[bbox_params_file, {'use_sim_time': use_sim_time}],
                 extra_arguments=[{'use_intra_process_comms': True}]
             ),
             ComposableNode(
@@ -69,7 +76,7 @@ def generate_launch_description():
                 plugin='image_to_position::MaskTo3D',
                 name='mask_to_3d',
                 namespace=namespace,
-                parameters=[mask_params_file],
+                parameters=[mask_params_file, {'use_sim_time': use_sim_time}],
                 extra_arguments=[{'use_intra_process_comms': True}]
             ),
             ComposableNode(
@@ -77,7 +84,7 @@ def generate_launch_description():
                 plugin='image_to_position::KeypointTo3D',
                 name='keypoint_to_3d',
                 namespace=namespace,
-                parameters=[keypoint_params_file],
+                parameters=[keypoint_params_file, {'use_sim_time': use_sim_time}],
                 extra_arguments=[{'use_intra_process_comms': True}]
             ),
         ],
@@ -158,6 +165,7 @@ def generate_launch_description():
 
     return LaunchDescription([
         execute_default_arg,
+        use_sim_time_arg,
         mask_params_arg,
         bbox_params_arg,
         keypoint_params_arg,

--- a/launch/keypoint_to_3d.launch.py
+++ b/launch/keypoint_to_3d.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
     
     params_file = LaunchConfiguration('params_file')
     execute_default = LaunchConfiguration('execute_default')
+    use_sim_time = LaunchConfiguration('use_sim_time')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
@@ -23,6 +24,11 @@ def generate_launch_description():
         'execute_default',
         default_value='False',
         description='Whether to start the node in the active state or not'
+    )
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='True',
+        description='Use simulation clock.',
     )
 
     namespace = LaunchConfiguration("namespace")
@@ -43,7 +49,7 @@ def generate_launch_description():
                 plugin='image_to_position::KeypointTo3D',
                 name='keypoint_to_3d',
                 namespace=namespace,
-                parameters=[params_file],
+                parameters=[params_file, {'use_sim_time': use_sim_time}],
                 extra_arguments=[{'use_intra_process_comms': True}]
             ),
         ],
@@ -78,6 +84,7 @@ def generate_launch_description():
     return LaunchDescription([
         params_file_arg,
         execute_default_arg,
+        use_sim_time_arg,
         namespace_cmd,
         container,
         TimerAction(period=0.1, actions=[configure_node]),

--- a/launch/mask_to_3d.launch.py
+++ b/launch/mask_to_3d.launch.py
@@ -14,6 +14,7 @@ def generate_launch_description():
     
     params_file = LaunchConfiguration('params_file')
     execute_default = LaunchConfiguration('execute_default')
+    use_sim_time = LaunchConfiguration('use_sim_time')
     params_file_arg = DeclareLaunchArgument(
         'params_file',
         default_value=default_params_file,
@@ -23,6 +24,11 @@ def generate_launch_description():
         'execute_default',
         default_value='False',
         description='Whether to start the node in the active state or not'
+    )
+    use_sim_time_arg = DeclareLaunchArgument(
+        'use_sim_time',
+        default_value='True',
+        description='Use simulation clock.',
     )
 
     namespace = LaunchConfiguration("namespace")
@@ -43,7 +49,7 @@ def generate_launch_description():
                 plugin='image_to_position::MaskTo3D',
                 name='mask_to_3d',
                 namespace=namespace,
-                parameters=[params_file],
+                parameters=[params_file, {'use_sim_time': use_sim_time}],
                 extra_arguments=[{'use_intra_process_comms': True}]
             ),
         ],
@@ -79,6 +85,7 @@ def generate_launch_description():
     return LaunchDescription([
         params_file_arg,
         execute_default_arg,
+        use_sim_time_arg,
         namespace_cmd,
         container,
         TimerAction(period=0.1, actions=[configure_node]),


### PR DESCRIPTION
This pull request updates all of the launch files for the 3D processing nodes to support simulation time. The main change is the addition of a `use_sim_time` launch argument to each file, which is then passed to the relevant nodes as a parameter. This allows the nodes to use the simulation clock when running in a simulated environment, improving compatibility with ROS 2 simulation workflows.

Key changes by theme:

**Simulation time support:**

* Added a `use_sim_time` launch argument (defaulting to `True`) to `bbox_to_3d.launch.py`, `keypoint_to_3d.launch.py`, `mask_to_3d.launch.py`, and `image_to_3d.launch.py`. This argument is now included in each node's parameters so they can use the simulation clock when required. [[1]](diffhunk://#diff-99367f239f908a59d0049cecc7aed0a3b4519f4c9f177d59b4b9bd2f971288f9R17) [[2]](diffhunk://#diff-99367f239f908a59d0049cecc7aed0a3b4519f4c9f177d59b4b9bd2f971288f9R28-R32) [[3]](diffhunk://#diff-99367f239f908a59d0049cecc7aed0a3b4519f4c9f177d59b4b9bd2f971288f9L46-R52) [[4]](diffhunk://#diff-99367f239f908a59d0049cecc7aed0a3b4519f4c9f177d59b4b9bd2f971288f9R87) [[5]](diffhunk://#diff-3aa549d11831a36fd03703d0f8a2f9604422a21696366d7c3a3c7adfc79a96e3R17) [[6]](diffhunk://#diff-3aa549d11831a36fd03703d0f8a2f9604422a21696366d7c3a3c7adfc79a96e3R28-R32) [[7]](diffhunk://#diff-3aa549d11831a36fd03703d0f8a2f9604422a21696366d7c3a3c7adfc79a96e3L46-R52) [[8]](diffhunk://#diff-3aa549d11831a36fd03703d0f8a2f9604422a21696366d7c3a3c7adfc79a96e3R87) [[9]](diffhunk://#diff-bb592836fcb6a836f60a48a073c9afe6de9211ce67883006a513815e291e0e7eR17) [[10]](diffhunk://#diff-bb592836fcb6a836f60a48a073c9afe6de9211ce67883006a513815e291e0e7eR28-R32) [[11]](diffhunk://#diff-bb592836fcb6a836f60a48a073c9afe6de9211ce67883006a513815e291e0e7eL46-R52) [[12]](diffhunk://#diff-bb592836fcb6a836f60a48a073c9afe6de9211ce67883006a513815e291e0e7eR88) [[13]](diffhunk://#diff-16ced8ca7a9bf59f1a1a537b70bca76eca5ea3888ff95e2ff71f32a64977668fR21-R27) [[14]](diffhunk://#diff-16ced8ca7a9bf59f1a1a537b70bca76eca5ea3888ff95e2ff71f32a64977668fL64-R87) [[15]](diffhunk://#diff-16ced8ca7a9bf59f1a1a537b70bca76eca5ea3888ff95e2ff71f32a64977668fR168)

**Launch file consistency:**

* Ensured that all relevant nodes in `image_to_3d.launch.py` (`BboxTo3D`, `MaskTo3D`, and `KeypointTo3D`) receive the `use_sim_time` parameter, aligning behavior across all 3D processing launch files.

**Launch argument registration:**

* Registered the new `use_sim_time` argument in the launch descriptions so it can be set via the command line or launch files, and included it in the launch description return values for all affected files. [[1]](diffhunk://#diff-99367f239f908a59d0049cecc7aed0a3b4519f4c9f177d59b4b9bd2f971288f9R87) [[2]](diffhunk://#diff-3aa549d11831a36fd03703d0f8a2f9604422a21696366d7c3a3c7adfc79a96e3R87) [[3]](diffhunk://#diff-bb592836fcb6a836f60a48a073c9afe6de9211ce67883006a513815e291e0e7eR88) [[4]](diffhunk://#diff-16ced8ca7a9bf59f1a1a537b70bca76eca5ea3888ff95e2ff71f32a64977668fR168)